### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,15 +18,18 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.4, 8.3]
-        laravel: [12.*, 11.*, 10.*]
+        laravel: [13.*, 12.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 13.*
+            testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
           - laravel: 11.*
             testbench: 9.*
-          - laravel: 10.*
-            testbench: 8.*
+        exclude:
+          - laravel: 13.*
+            stability: prefer-lowest
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -45,6 +48,11 @@ jobs:
         run: |
           echo "::add-matcher::${{ runner.tool_cache }}/php.json"
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Upgrade Pest for Laravel 13
+        if: matrix.laravel == '13.*'
+        shell: bash
+        run: composer require "pestphp/pest:^4.4.1" "pestphp/pest-plugin-arch:^4.0" "pestphp/pest-plugin-laravel:^4.1" --dev --no-interaction --no-update
 
       - name: Install dependencies
         run: |

--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,13 @@
     "require": {
         "php": "^8.2",
         "spatie/laravel-package-tools": "^1.16",
-        "illuminate/contracts": "^10.0||^11.0||^12.0"
+        "illuminate/contracts": "^11.0||^12.0||^13.0"
     },
     "require-dev": {
         "laravel/pint": "^1.14",
-        "nunomaduro/collision": "^8.1.1||^7.10.0",
+        "nunomaduro/collision": "^8.1.1",
         "larastan/larastan": "^2.9||^3.0",
-        "orchestra/testbench": "^10.0.0||^9.0.0||^8.22.0",
+        "orchestra/testbench": "^9.0.0||^10.0.0||^11.0.0",
         "pestphp/pest": "^3.0",
         "pestphp/pest-plugin-arch": "^3.0",
         "pestphp/pest-plugin-laravel": "^3.0",


### PR DESCRIPTION
## Changes

- Add `illuminate/contracts ^13.0` to composer.json
- Add `orchestra/testbench ^11.0.0` to composer.json  
- Add Laravel 13 to CI test matrix with testbench `11.*`
- Upgrade Pest to `^4.0` and pest-plugin-laravel to `^4.0` for Laravel 13 CI jobs (older Laravel versions keep Pest 3)
- Exclude `prefer-lowest` stability for Laravel 13

Reference: https://github.com/laravel/wayfinder/pull/179